### PR TITLE
Add prettier-plugin-astro

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/jgonera/prettier-config-jgonera#readme",
   "dependencies": {
+    "prettier-plugin-astro": "^0.14.0",
     "prettier-plugin-embed": "^0.5.0",
     "prettier-plugin-sql": "^0.18.1"
   },

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,11 @@
 /** @type {import("prettier").Config} */
 const config = {
   semi: false,
-  plugins: ["prettier-plugin-astro", "prettier-plugin-embed", "prettier-plugin-sql"],
+  plugins: [
+    "prettier-plugin-astro",
+    "prettier-plugin-embed",
+    "prettier-plugin-sql",
+  ],
   proseWrap: "always",
   // prettier-plugin-sql options
   formatter: "sql-formatter",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,7 @@
 /** @type {import("prettier").Config} */
 const config = {
   semi: false,
-  plugins: ["prettier-plugin-embed", "prettier-plugin-sql"],
+  plugins: ["prettier-plugin-astro", "prettier-plugin-embed", "prettier-plugin-sql"],
   proseWrap: "always",
   // prettier-plugin-sql options
   formatter: "sql-formatter",


### PR DESCRIPTION
Adds `prettier-plugin-astro` to the shared prettier config as a dependency and registers it in the plugins array.

Closes #7

Generated with [Claude Code](https://claude.ai/code)